### PR TITLE
Update CurlPost.php

### DIFF
--- a/RequestMethod/CurlPost.php
+++ b/RequestMethod/CurlPost.php
@@ -25,7 +25,7 @@ class CurlPost implements RequestMethod
      */
     protected $curl;
 
-    protected $options;
+    protected $options = array();
     
     /**
      * CurlPost constructor.


### PR DESCRIPTION
If protected $options not define as ARRAY (defined as NULL), then array_replace return NULL:
$this->curl->setoptArray($handle, array_replace($options , $this->options));